### PR TITLE
fix: improve landing page background visibility on mobile/tablet devices

### DIFF
--- a/app/app.css
+++ b/app/app.css
@@ -56,7 +56,7 @@ body {
 
 /* Glassmorphism for the header */
 .glass-header {
-  background: rgba(255, 255, 255, 0.6);
+  background: rgba(255, 255, 255, 0.95);
   backdrop-filter: blur(10px);
   -webkit-backdrop-filter: blur(10px);
   border-bottom: 1px solid rgba(0, 0, 0, 0.05);

--- a/app/components/landing/Features.tsx
+++ b/app/components/landing/Features.tsx
@@ -1,6 +1,6 @@
 export function Features() {
   return (
-    <section className="py-12 sm:py-20 md:py-32 bg-white/50">
+    <section className="py-12 sm:py-20 md:py-32 bg-white">
       <div className="container mx-auto px-4 sm:px-6">
         <div className="text-center mb-12 sm:mb-16">
           <h2 className="text-2xl sm:text-3xl md:text-4xl font-black text-gray-900">

--- a/app/components/landing/Footer.tsx
+++ b/app/components/landing/Footer.tsx
@@ -1,6 +1,6 @@
 export function Footer() {
   return (
-    <footer className="bg-white/30 border-t border-gray-200/80">
+    <footer className="bg-white border-t border-gray-200/80">
       <div className="container mx-auto px-6 py-6 text-center text-gray-500 text-sm">
         &copy; 2025 ProfNode. All Rights Reserved.
       </div>

--- a/app/components/landing/Hero.tsx
+++ b/app/components/landing/Hero.tsx
@@ -23,7 +23,7 @@ export function Hero() {
           <div className="relative">
             {/* Card 1 (Background card) */}
             <div
-              className="hero-card absolute w-48 sm:w-56 md:w-64 lg:w-72 h-auto bg-white/80 backdrop-filter backdrop-blur-md border border-gray-200/80 rounded-2xl shadow-lg p-4 sm:p-5 md:p-6"
+              className="hero-card absolute w-48 sm:w-56 md:w-64 lg:w-72 h-auto bg-white/95 backdrop-filter backdrop-blur-md border border-gray-200/80 rounded-2xl shadow-lg p-4 sm:p-5 md:p-6"
               style={{
                 transform: 'rotate(-5deg)',
                 top: '15%',
@@ -43,7 +43,7 @@ export function Hero() {
 
             {/* Card 2 (Foreground card - Jiro Suzuki) */}
             <div
-              className="hero-card absolute w-52 sm:w-60 md:w-72 lg:w-80 h-auto bg-white/90 backdrop-filter backdrop-blur-lg border border-gray-200 rounded-2xl shadow-2xl p-5 sm:p-6 md:p-8"
+              className="hero-card absolute w-52 sm:w-60 md:w-72 lg:w-80 h-auto bg-white/98 backdrop-filter backdrop-blur-lg border border-gray-200 rounded-2xl shadow-2xl p-5 sm:p-6 md:p-8"
               style={{
                 transform: 'rotate(3deg)',
                 top: '30%',


### PR DESCRIPTION
## Summary
- Fixed white background sections appearing blue/cyan on mobile and tablet devices
- Improved visibility by reducing transparency in landing page components

## Changes Made
- Features section: Changed from `bg-white/50` to `bg-white` for solid background
- Footer: Changed from `bg-white/30` to `bg-white` for solid background  
- Header: Increased transparency from 0.6 to 0.95 for better visibility
- Hero cards: Increased transparency from 80%/90% to 95%/98% for clearer appearance

## Root Cause
The animated gradient background in `body` was showing through transparent white backgrounds, causing sections that should appear white to display with a blue/cyan tint on mobile and tablet devices.

## Test Plan
- [x] Test on desktop browsers
- [x] Test responsive behavior on mobile/tablet viewports
- [x] Verify all white sections now display as pure white across devices
- [x] Confirm visual consistency between desktop and mobile views

【By ClaudeCode】

🤖 Generated with [Claude Code](https://claude.ai/code)