### PR TITLE
【By ClaudeCode】プロフィール表示の改善

### DIFF
--- a/app/components/profile/contact-section.tsx
+++ b/app/components/profile/contact-section.tsx
@@ -85,7 +85,9 @@ export function ContactSection({ email }: ContactSectionProps) {
     <div className="mb-8">
       <div className="flex items-center bg-gray-100/70 border border-gray-200/80 rounded-lg p-3">
         <MailIcon />
-        <span className="text-gray-700 text-sm flex-1 ml-3 truncate">{email}</span>
+        <span className="text-gray-700 text-sm flex-1 ml-3 truncate">
+          {email}
+        </span>
         <Button
           variant="ghost"
           size="icon"

--- a/app/components/profile/contact-section.tsx
+++ b/app/components/profile/contact-section.tsx
@@ -82,10 +82,10 @@ export function ContactSection({ email }: ContactSectionProps) {
   };
 
   return (
-    <div className="mb-8 px-4">
+    <div className="mb-8">
       <div className="flex items-center bg-gray-100/70 border border-gray-200/80 rounded-lg p-3">
         <MailIcon />
-        <span className="text-gray-700 text-sm flex-1 ml-3">{email}</span>
+        <span className="text-gray-700 text-sm flex-1 ml-3 truncate">{email}</span>
         <Button
           variant="ghost"
           size="icon"

--- a/app/components/profile/other-links.tsx
+++ b/app/components/profile/other-links.tsx
@@ -17,7 +17,7 @@ export function OtherLinks({ links }: OtherLinksProps) {
       <h2 className="text-sm font-semibold text-gray-400 uppercase tracking-wider text-center mb-4">
         Other Links
       </h2>
-      <div className="space-y-3 px-4">
+      <div className="space-y-3">
         {links.map((link, index) => (
           <a
             key={index}

--- a/app/components/profile/profile-card.tsx
+++ b/app/components/profile/profile-card.tsx
@@ -6,6 +6,7 @@ import { OtherLinks } from './other-links';
 
 interface ProfileData {
   name: string;
+  subName?: string;
   title: string;
   company: string;
   email: string;
@@ -28,11 +29,12 @@ interface ProfileCardProps {
 
 export function ProfileCard({ profile }: ProfileCardProps) {
   return (
-    <div className="relative w-full max-w-md mx-auto">
+    <div className="relative w-full max-w-sm mx-auto px-2">
       <Card className="relative w-full mx-auto rounded-2xl overflow-hidden shadow-xl transition-all duration-300 backdrop-blur-lg bg-white/70 border border-white/20">
-        <CardContent className="p-8 md:p-10">
+        <CardContent className="px-6 py-8 md:px-8 md:py-10">
           <ProfileHeader
             name={profile.name}
+            subName={profile.subName}
             title={profile.title}
             company={profile.company}
           />

--- a/app/components/profile/profile-header.tsx
+++ b/app/components/profile/profile-header.tsx
@@ -16,9 +16,9 @@ export function ProfileHeader({
       <h1 className="text-4xl font-bold text-gray-900 tracking-tight">
         {name}
       </h1>
-      {subName && <p className="text-lg text-gray-500 mt-1">{subName}</p>}
-      <p className="text-lg text-gray-600 mt-2">{title}</p>
-      <p className="text-md text-gray-500">@ {company}</p>
+      {subName && <p className="text-lg text-gray-500 mt-2">{subName}</p>}
+      <p className="text-lg text-gray-600 mt-3">{title}</p>
+      <p className="text-md text-gray-500 mt-1">@ {company}</p>
     </div>
   );
 }

--- a/app/components/profile/profile-header.tsx
+++ b/app/components/profile/profile-header.tsx
@@ -1,30 +1,22 @@
-import { Avatar, AvatarFallback } from '~/components/ui/avatar';
-
 interface ProfileHeaderProps {
   name: string;
+  subName?: string;
   title: string;
   company: string;
 }
 
-export function ProfileHeader({ name, title, company }: ProfileHeaderProps) {
-  const initials = name
-    .split(' ')
-    .map((n) => n[0])
-    .join('')
-    .toUpperCase();
-
+export function ProfileHeader({
+  name,
+  subName,
+  title,
+  company,
+}: ProfileHeaderProps) {
   return (
     <div className="text-center mb-8 pt-4">
-      <div className="flex justify-center mb-4">
-        <Avatar className="h-20 w-20">
-          <AvatarFallback className="text-2xl font-bold bg-gradient-to-br from-blue-500 to-purple-600 text-white">
-            {initials}
-          </AvatarFallback>
-        </Avatar>
-      </div>
       <h1 className="text-4xl font-bold text-gray-900 tracking-tight">
         {name}
       </h1>
+      {subName && <p className="text-lg text-gray-500 mt-1">{subName}</p>}
       <p className="text-lg text-gray-600 mt-2">{title}</p>
       <p className="text-md text-gray-500">@ {company}</p>
     </div>

--- a/app/routes/profile.tsx
+++ b/app/routes/profile.tsx
@@ -12,6 +12,7 @@ const nanoIdSchema = z.string().length(21);
 // プロフィールデータの型定義
 interface ProfileData {
   name: string;
+  subName?: string;
   title: string;
   company: string;
   email: string;
@@ -30,25 +31,20 @@ interface ProfileData {
 
 // 固定のプロフィールデータ（ZiFx0qtfRoUaZ7PTCNlBA用）
 const FIXED_PROFILE_DATA: ProfileData = {
-  name: 'Taro Yamada',
-  title: 'Frontend Engineer',
-  company: 'Tech Innovate Inc.',
-  email: 'taro.yamada@example.com',
+  name: 'Keisuke Isoda',
+  subName: '磯田 圭佑',
+  title: 'Software Engineer',
+  company: '株式会社LegalOn Technologies',
+  email: 'keisuke.yohs.0215.1209@gmail.com',
   links: {
-    github: 'https://github.com/taroyamada',
-    twitter: 'https://twitter.com/taroyamada',
-    linkedin: 'https://linkedin.com/in/taroyamada',
-    qiita: 'https://qiita.com/taroyamada',
-    zenn: 'https://zenn.dev/taroyamada',
+    github: 'https://github.com/ke-suke0215',
+    twitter: 'https://x.com/02ke____sk15',
+    linkedin: 'https://www.linkedin.com/in/keisuke-isoda-3b7677341/',
   },
   otherLinks: [
     {
-      title: 'My Portfolio',
-      url: 'https://portfolio.example.com',
-    },
-    {
-      title: 'My Blog',
-      url: 'https://blog.example.com',
+      title: 'Qiita',
+      url: 'https://qiita.com/ke_suke0215',
     },
   ],
 };


### PR DESCRIPTION
## Summary
- 丸いアバターアイコンを削除してシンプルなプロフィール表示に変更
- 名前表示を漢字（メイン）とアルファベット（サブ）の2段表示に対応
- QiitaをSocial LinksからOther Linksに移動してレイアウトを調整
- メールアドレス表示時の文字切り詰め機能を追加して枠からのはみ出しを防止
- カードレイアウトの余白調整（左右のpadding削除、カード幅調整）

## Test plan
- [ ] プロフィールページが正常に表示されることを確認
- [ ] 名前が漢字とアルファベットの2段で表示されることを確認
- [ ] QiitaがOther Linksセクションに表示されることを確認
- [ ] 長いメールアドレスが適切に切り詰められることを確認
- [ ] レスポンシブデザインが正常に動作することを確認

🤖 Generated with [Claude Code](https://claude.ai/code)