### PR TITLE
【By ClaudeCode】ユーザー登録ページ実装

### DIFF
--- a/app/components/auth/AuthForm.tsx
+++ b/app/components/auth/AuthForm.tsx
@@ -1,0 +1,49 @@
+interface FormFieldProps {
+  id: string;
+  label: string;
+  type: string;
+  autoComplete?: string;
+  placeholder?: string;
+  required?: boolean;
+}
+
+export function FormField({
+  id,
+  label,
+  type,
+  autoComplete,
+  placeholder,
+  required = false,
+}: FormFieldProps) {
+  return (
+    <div>
+      <label htmlFor={id} className="block text-sm font-medium text-gray-700">
+        {label}
+      </label>
+      <div className="mt-1">
+        <input
+          id={id}
+          name={id}
+          type={type}
+          autoComplete={autoComplete}
+          required={required}
+          className="appearance-none block w-full px-3 py-2 border border-gray-300 rounded-lg placeholder-gray-400 focus:outline-none focus:ring-blue-500 focus:border-blue-500 sm:text-sm"
+          placeholder={placeholder}
+        />
+      </div>
+    </div>
+  );
+}
+
+export function Divider({ children }: { children: React.ReactNode }) {
+  return (
+    <div className="relative">
+      <div className="absolute inset-0 flex items-center">
+        <div className="w-full border-t border-gray-300" />
+      </div>
+      <div className="relative flex justify-center text-sm">
+        <span className="px-2 bg-white text-gray-500">{children}</span>
+      </div>
+    </div>
+  );
+}

--- a/app/components/auth/AuthForm.tsx
+++ b/app/components/auth/AuthForm.tsx
@@ -17,7 +17,10 @@ export function FormField({
 }: FormFieldProps) {
   return (
     <div>
-      <label htmlFor={id} className="block text-sm font-medium text-gray-700">
+      <label
+        htmlFor={id}
+        className="block text-xs sm:text-sm font-medium text-gray-700"
+      >
         {label}
       </label>
       <div className="mt-1">
@@ -27,7 +30,7 @@ export function FormField({
           type={type}
           autoComplete={autoComplete}
           required={required}
-          className="appearance-none block w-full px-3 py-2 border border-gray-300 rounded-lg placeholder-gray-400 focus:outline-none focus:ring-blue-500 focus:border-blue-500 sm:text-sm"
+          className="appearance-none block w-full px-3 py-2 sm:py-2.5 border border-gray-300 rounded-lg placeholder-gray-400 focus:outline-none focus:ring-blue-500 focus:border-blue-500 text-sm sm:text-base"
           placeholder={placeholder}
         />
       </div>

--- a/app/components/auth/AuthLayout.tsx
+++ b/app/components/auth/AuthLayout.tsx
@@ -1,0 +1,30 @@
+interface AuthLayoutProps {
+  title: string;
+  subtitle: string;
+  description: string;
+  children: React.ReactNode;
+}
+
+export function AuthLayout({
+  title,
+  subtitle: _subtitle,
+  description,
+  children,
+}: AuthLayoutProps) {
+  return (
+    <div className="min-h-screen animated-gradient flex flex-col justify-center py-12 sm:px-6 lg:px-8">
+      <div className="sm:mx-auto sm:w-full sm:max-w-md">
+        <div className="text-center">
+          <h1 className="text-2xl font-black text-gray-900">{title}</h1>
+          <p className="mt-1 text-sm text-gray-600">{description}</p>
+        </div>
+      </div>
+
+      <div className="mt-8 sm:mx-auto sm:w-full sm:max-w-md">
+        <div className="bg-white/80 backdrop-filter backdrop-blur-md py-8 px-4 shadow-2xl sm:rounded-2xl sm:px-10 border border-gray-200/80">
+          {children}
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/app/components/auth/AuthLayout.tsx
+++ b/app/components/auth/AuthLayout.tsx
@@ -12,7 +12,7 @@ export function AuthLayout({
   children,
 }: AuthLayoutProps) {
   return (
-    <div className="min-h-screen animated-gradient flex flex-col justify-center py-8 px-4 sm:py-12 sm:px-6 lg:px-8">
+    <div className="min-h-screen animated-gradient flex flex-col justify-center py-4 px-4 sm:py-12 sm:px-6 lg:px-8">
       <div className="sm:mx-auto sm:w-full sm:max-w-md">
         <div className="text-center">
           <h1 className="text-xl sm:text-2xl font-black text-gray-900">
@@ -24,7 +24,7 @@ export function AuthLayout({
         </div>
       </div>
 
-      <div className="mt-6 sm:mt-8 sm:mx-auto sm:w-full sm:max-w-md">
+      <div className="mt-4 sm:mt-8 sm:mx-auto sm:w-full sm:max-w-md">
         <div className="bg-white/80 backdrop-filter backdrop-blur-md py-6 px-4 sm:py-8 shadow-2xl rounded-xl sm:rounded-2xl sm:px-10 border border-gray-200/80">
           {children}
         </div>

--- a/app/components/auth/AuthLayout.tsx
+++ b/app/components/auth/AuthLayout.tsx
@@ -12,16 +12,20 @@ export function AuthLayout({
   children,
 }: AuthLayoutProps) {
   return (
-    <div className="min-h-screen animated-gradient flex flex-col justify-center py-12 sm:px-6 lg:px-8">
+    <div className="min-h-screen animated-gradient flex flex-col justify-center py-8 px-4 sm:py-12 sm:px-6 lg:px-8">
       <div className="sm:mx-auto sm:w-full sm:max-w-md">
         <div className="text-center">
-          <h1 className="text-2xl font-black text-gray-900">{title}</h1>
-          <p className="mt-1 text-sm text-gray-600">{description}</p>
+          <h1 className="text-xl sm:text-2xl font-black text-gray-900">
+            {title}
+          </h1>
+          <p className="mt-1 text-xs sm:text-sm text-gray-600 px-2">
+            {description}
+          </p>
         </div>
       </div>
 
-      <div className="mt-8 sm:mx-auto sm:w-full sm:max-w-md">
-        <div className="bg-white/80 backdrop-filter backdrop-blur-md py-8 px-4 shadow-2xl sm:rounded-2xl sm:px-10 border border-gray-200/80">
+      <div className="mt-6 sm:mt-8 sm:mx-auto sm:w-full sm:max-w-md">
+        <div className="bg-white/80 backdrop-filter backdrop-blur-md py-6 px-4 sm:py-8 shadow-2xl rounded-xl sm:rounded-2xl sm:px-10 border border-gray-200/80">
           {children}
         </div>
       </div>

--- a/app/components/auth/OAuthButton.tsx
+++ b/app/components/auth/OAuthButton.tsx
@@ -1,0 +1,51 @@
+interface OAuthButtonProps {
+  provider: 'google' | 'github';
+  children: React.ReactNode;
+  onClick?: () => void;
+}
+
+export function OAuthButton({ provider, children, onClick }: OAuthButtonProps) {
+  const ringColor =
+    provider === 'google' ? 'focus:ring-blue-500' : 'focus:ring-gray-500';
+
+  return (
+    <button
+      type="button"
+      onClick={onClick}
+      className={`w-full flex justify-center items-center px-4 py-3 border border-gray-300 rounded-lg shadow-sm bg-white text-sm font-medium text-gray-700 hover:bg-gray-50 focus:outline-none focus:ring-2 focus:ring-offset-2 ${ringColor} transition-colors`}
+    >
+      {children}
+    </button>
+  );
+}
+
+export function GoogleIcon() {
+  return (
+    <svg className="w-5 h-5 mr-3" viewBox="0 0 24 24">
+      <path
+        fill="#4285F4"
+        d="M22.56 12.25c0-.78-.07-1.53-.2-2.25H12v4.26h5.92c-.26 1.37-1.04 2.53-2.21 3.31v2.77h3.57c2.08-1.92 3.28-4.74 3.28-8.09z"
+      />
+      <path
+        fill="#34A853"
+        d="M12 23c2.97 0 5.46-.98 7.28-2.66l-3.57-2.77c-.98.66-2.23 1.06-3.71 1.06-2.86 0-5.29-1.93-6.16-4.53H2.18v2.84C3.99 20.53 7.7 23 12 23z"
+      />
+      <path
+        fill="#FBBC05"
+        d="M5.84 14.09c-.22-.66-.35-1.36-.35-2.09s.13-1.43.35-2.09V7.07H2.18C1.43 8.55 1 10.22 1 12s.43 3.45 1.18 4.93l2.85-2.22.81-.62z"
+      />
+      <path
+        fill="#EA4335"
+        d="M12 5.38c1.62 0 3.06.56 4.21 1.64l3.15-3.15C17.45 2.09 14.97 1 12 1 7.7 1 3.99 3.47 2.18 7.07l3.66 2.84c.87-2.6 3.3-4.53 6.16-4.53z"
+      />
+    </svg>
+  );
+}
+
+export function GitHubIcon() {
+  return (
+    <svg className="w-5 h-5 mr-3" fill="currentColor" viewBox="0 0 24 24">
+      <path d="M12 0a12 12 0 0 0-3.8 23.4c.6.1.8-.3.8-.6v-2.2c-3.3.7-4-1.6-4-1.6-.5-1.4-1.3-1.8-1.3-1.8-1.1-.7.1-.7.1-.7 1.2.1 1.8 1.2 1.8 1.2 1.1 1.8 2.8 1.3 3.5 1 .1-.8.4-1.3.8-1.6-2.7-.3-5.5-1.3-5.5-6 0-1.3.5-2.4 1.2-3.2-.1-.3-.5-1.5.1-3.2 0 0 1-.3 3.3 1.2a11.5 11.5 0 0 1 6 0c2.3-1.5 3.3-1.2 3.3-1.2.6 1.7.2 2.9.1 3.2.8.8 1.2 1.9 1.2 3.2 0 4.7-2.8 5.7-5.5 6 .4.4.8 1.1.8 2.2v3.3c0 .3.2.7.8.6A12 12 0 0 0 12 0z" />
+    </svg>
+  );
+}

--- a/app/components/auth/OAuthButton.tsx
+++ b/app/components/auth/OAuthButton.tsx
@@ -12,7 +12,7 @@ export function OAuthButton({ provider, children, onClick }: OAuthButtonProps) {
     <button
       type="button"
       onClick={onClick}
-      className={`w-full flex justify-center items-center px-4 py-3 border border-gray-300 rounded-lg shadow-sm bg-white text-sm font-medium text-gray-700 hover:bg-gray-50 focus:outline-none focus:ring-2 focus:ring-offset-2 ${ringColor} transition-colors`}
+      className={`w-full flex justify-center items-center px-3 py-2.5 sm:px-4 sm:py-3 border border-gray-300 rounded-lg shadow-sm bg-white text-xs sm:text-sm font-medium text-gray-700 hover:bg-gray-50 focus:outline-none focus:ring-2 focus:ring-offset-2 ${ringColor} transition-colors`}
     >
       {children}
     </button>
@@ -21,7 +21,7 @@ export function OAuthButton({ provider, children, onClick }: OAuthButtonProps) {
 
 export function GoogleIcon() {
   return (
-    <svg className="w-5 h-5 mr-3" viewBox="0 0 24 24">
+    <svg className="w-4 h-4 sm:w-5 sm:h-5 mr-2 sm:mr-3" viewBox="0 0 24 24">
       <path
         fill="#4285F4"
         d="M22.56 12.25c0-.78-.07-1.53-.2-2.25H12v4.26h5.92c-.26 1.37-1.04 2.53-2.21 3.31v2.77h3.57c2.08-1.92 3.28-4.74 3.28-8.09z"
@@ -44,7 +44,11 @@ export function GoogleIcon() {
 
 export function GitHubIcon() {
   return (
-    <svg className="w-5 h-5 mr-3" fill="currentColor" viewBox="0 0 24 24">
+    <svg
+      className="w-4 h-4 sm:w-5 sm:h-5 mr-2 sm:mr-3"
+      fill="currentColor"
+      viewBox="0 0 24 24"
+    >
       <path d="M12 0a12 12 0 0 0-3.8 23.4c.6.1.8-.3.8-.6v-2.2c-3.3.7-4-1.6-4-1.6-.5-1.4-1.3-1.8-1.3-1.8-1.1-.7.1-.7.1-.7 1.2.1 1.8 1.2 1.8 1.2 1.1 1.8 2.8 1.3 3.5 1 .1-.8.4-1.3.8-1.6-2.7-.3-5.5-1.3-5.5-6 0-1.3.5-2.4 1.2-3.2-.1-.3-.5-1.5.1-3.2 0 0 1-.3 3.3 1.2a11.5 11.5 0 0 1 6 0c2.3-1.5 3.3-1.2 3.3-1.2.6 1.7.2 2.9.1 3.2.8.8 1.2 1.9 1.2 3.2 0 4.7-2.8 5.7-5.5 6 .4.4.8 1.1.8 2.2v3.3c0 .3.2.7.8.6A12 12 0 0 0 12 0z" />
     </svg>
   );

--- a/app/components/landing/CTA.tsx
+++ b/app/components/landing/CTA.tsx
@@ -15,7 +15,10 @@ export function CTA() {
           Web名刺を始めよう。
         </h2>
         <div className="mt-6 sm:mt-8">
-          <a href="/register" className="inline-block bg-blue-600 text-white font-bold py-3 px-6 sm:py-4 sm:px-10 rounded-lg text-lg sm:text-xl hover:bg-blue-700 transition-all duration-300 transform hover:scale-105 border-none cursor-pointer text-center">
+          <a
+            href="/register"
+            className="inline-block bg-blue-600 text-white font-bold py-3 px-6 sm:py-4 sm:px-10 rounded-lg text-lg sm:text-xl hover:bg-blue-700 transition-all duration-300 transform hover:scale-105 border-none cursor-pointer text-center"
+          >
             今すぐ無料で作成
           </a>
         </div>

--- a/app/components/landing/CTA.tsx
+++ b/app/components/landing/CTA.tsx
@@ -15,9 +15,9 @@ export function CTA() {
           Web名刺を始めよう。
         </h2>
         <div className="mt-6 sm:mt-8">
-          <button className="inline-block bg-blue-600 text-white font-bold py-3 px-6 sm:py-4 sm:px-10 rounded-lg text-lg sm:text-xl hover:bg-blue-700 transition-all duration-300 transform hover:scale-105 border-none cursor-pointer">
+          <a href="/register" className="inline-block bg-blue-600 text-white font-bold py-3 px-6 sm:py-4 sm:px-10 rounded-lg text-lg sm:text-xl hover:bg-blue-700 transition-all duration-300 transform hover:scale-105 border-none cursor-pointer text-center">
             今すぐ無料で作成
-          </button>
+          </a>
         </div>
       </div>
     </section>

--- a/app/components/landing/Header.tsx
+++ b/app/components/landing/Header.tsx
@@ -6,12 +6,12 @@ export function Header() {
           ProfNode
         </div>
         <div className="flex items-center space-x-2 sm:space-x-4">
-          <button className="text-gray-600 hover:text-blue-600 bg-transparent border-none cursor-pointer text-sm sm:text-base px-2 sm:px-0">
+          <a href="/login" className="text-gray-600 hover:text-blue-600 bg-transparent border-none cursor-pointer text-sm sm:text-base px-2 sm:px-0">
             ログイン
-          </button>
-          <button className="bg-blue-600 text-white font-bold py-2 px-3 sm:px-4 rounded-lg hover:bg-blue-700 transition-colors cursor-pointer border-none text-sm sm:text-base">
+          </a>
+          <a href="/register" className="bg-blue-600 text-white font-bold py-2 px-3 sm:px-4 rounded-lg hover:bg-blue-700 transition-colors cursor-pointer border-none text-sm sm:text-base inline-block text-center">
             無料で始める
-          </button>
+          </a>
         </div>
       </div>
     </header>

--- a/app/components/landing/Header.tsx
+++ b/app/components/landing/Header.tsx
@@ -6,10 +6,16 @@ export function Header() {
           ProfNode
         </div>
         <div className="flex items-center space-x-2 sm:space-x-4">
-          <a href="/login" className="text-gray-600 hover:text-blue-600 bg-transparent border-none cursor-pointer text-sm sm:text-base px-2 sm:px-0">
+          <a
+            href="/login"
+            className="text-gray-600 hover:text-blue-600 bg-transparent border-none cursor-pointer text-sm sm:text-base px-2 sm:px-0"
+          >
             ログイン
           </a>
-          <a href="/register" className="bg-blue-600 text-white font-bold py-2 px-3 sm:px-4 rounded-lg hover:bg-blue-700 transition-colors cursor-pointer border-none text-sm sm:text-base inline-block text-center">
+          <a
+            href="/register"
+            className="bg-blue-600 text-white font-bold py-2 px-3 sm:px-4 rounded-lg hover:bg-blue-700 transition-colors cursor-pointer border-none text-sm sm:text-base inline-block text-center"
+          >
             無料で始める
           </a>
         </div>

--- a/app/components/landing/Hero.tsx
+++ b/app/components/landing/Hero.tsx
@@ -18,7 +18,10 @@ export function Hero() {
             ProfNodeは、あなたのプロフィールやSNS、ポートフォリオを一つにまとめ、簡単に共有できるデジタル名刺サービスです。
           </p>
           <div className="mt-6 sm:mt-8">
-            <a href="/register" className="inline-block bg-blue-600 text-white font-bold py-3 px-6 sm:px-8 rounded-lg text-base sm:text-lg hover:bg-blue-700 transition-all duration-300 transform hover:scale-105 border-none cursor-pointer text-center">
+            <a
+              href="/register"
+              className="inline-block bg-blue-600 text-white font-bold py-3 px-6 sm:px-8 rounded-lg text-base sm:text-lg hover:bg-blue-700 transition-all duration-300 transform hover:scale-105 border-none cursor-pointer text-center"
+            >
               今すぐ無料で作成
             </a>
           </div>

--- a/app/components/landing/Hero.tsx
+++ b/app/components/landing/Hero.tsx
@@ -18,9 +18,9 @@ export function Hero() {
             ProfNodeは、あなたのプロフィールやSNS、ポートフォリオを一つにまとめ、簡単に共有できるデジタル名刺サービスです。
           </p>
           <div className="mt-6 sm:mt-8">
-            <button className="inline-block bg-blue-600 text-white font-bold py-3 px-6 sm:px-8 rounded-lg text-base sm:text-lg hover:bg-blue-700 transition-all duration-300 transform hover:scale-105 border-none cursor-pointer">
+            <a href="/register" className="inline-block bg-blue-600 text-white font-bold py-3 px-6 sm:px-8 rounded-lg text-base sm:text-lg hover:bg-blue-700 transition-all duration-300 transform hover:scale-105 border-none cursor-pointer text-center">
               今すぐ無料で作成
-            </button>
+            </a>
           </div>
         </div>
 

--- a/app/routes.ts
+++ b/app/routes.ts
@@ -2,5 +2,6 @@ import { type RouteConfig, index, route } from '@react-router/dev/routes';
 
 export default [
   index('routes/home.tsx'),
+  route('register', 'routes/register.tsx'),
   route(':nanoId', 'routes/profile.tsx'),
 ] satisfies RouteConfig;

--- a/app/routes/register.tsx
+++ b/app/routes/register.tsx
@@ -1,0 +1,159 @@
+export function meta() {
+  return [
+    { title: 'アカウント登録 - ProfNode' },
+    {
+      name: 'description',
+      content: 'ProfNodeでアカウントを作成して、あなただけのデジタル名刺を始めましょう。',
+    },
+  ];
+}
+
+export default function Register() {
+  return (
+    <div className="min-h-screen animated-gradient flex flex-col justify-center py-12 sm:px-6 lg:px-8">
+      <div className="sm:mx-auto sm:w-full sm:max-w-md">
+        <div className="text-center">
+          <h1 className="text-3xl font-black text-gray-900 mb-2">
+            ProfNode
+          </h1>
+          <h2 className="text-xl font-bold text-gray-700">
+            アカウント作成
+          </h2>
+          <p className="mt-2 text-sm text-gray-600">
+            あなただけのデジタル名刺を始めましょう
+          </p>
+        </div>
+      </div>
+
+      <div className="mt-8 sm:mx-auto sm:w-full sm:max-w-md">
+        <div className="bg-white/80 backdrop-filter backdrop-blur-md py-8 px-4 shadow-2xl sm:rounded-2xl sm:px-10 border border-gray-200/80">
+          <div className="space-y-6">
+            {/* Google OAuth Button */}
+            <div>
+              <button
+                type="button"
+                className="w-full flex justify-center items-center px-4 py-3 border border-gray-300 rounded-lg shadow-sm bg-white text-sm font-medium text-gray-700 hover:bg-gray-50 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-blue-500 transition-colors"
+              >
+                <svg className="w-5 h-5 mr-3" viewBox="0 0 24 24">
+                  <path
+                    fill="#4285F4"
+                    d="M22.56 12.25c0-.78-.07-1.53-.2-2.25H12v4.26h5.92c-.26 1.37-1.04 2.53-2.21 3.31v2.77h3.57c2.08-1.92 3.28-4.74 3.28-8.09z"
+                  />
+                  <path
+                    fill="#34A853"
+                    d="M12 23c2.97 0 5.46-.98 7.28-2.66l-3.57-2.77c-.98.66-2.23 1.06-3.71 1.06-2.86 0-5.29-1.93-6.16-4.53H2.18v2.84C3.99 20.53 7.7 23 12 23z"
+                  />
+                  <path
+                    fill="#FBBC05"
+                    d="M5.84 14.09c-.22-.66-.35-1.36-.35-2.09s.13-1.43.35-2.09V7.07H2.18C1.43 8.55 1 10.22 1 12s.43 3.45 1.18 4.93l2.85-2.22.81-.62z"
+                  />
+                  <path
+                    fill="#EA4335"
+                    d="M12 5.38c1.62 0 3.06.56 4.21 1.64l3.15-3.15C17.45 2.09 14.97 1 12 1 7.7 1 3.99 3.47 2.18 7.07l3.66 2.84c.87-2.6 3.3-4.53 6.16-4.53z"
+                  />
+                </svg>
+                Googleでアカウント作成
+              </button>
+            </div>
+
+            {/* GitHub OAuth Button */}
+            <div>
+              <button
+                type="button"
+                className="w-full flex justify-center items-center px-4 py-3 border border-gray-300 rounded-lg shadow-sm bg-white text-sm font-medium text-gray-700 hover:bg-gray-50 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-gray-500 transition-colors"
+              >
+                <svg className="w-5 h-5 mr-3" fill="currentColor" viewBox="0 0 24 24">
+                  <path d="M12 0a12 12 0 0 0-3.8 23.4c.6.1.8-.3.8-.6v-2.2c-3.3.7-4-1.6-4-1.6-.5-1.4-1.3-1.8-1.3-1.8-1.1-.7.1-.7.1-.7 1.2.1 1.8 1.2 1.8 1.2 1.1 1.8 2.8 1.3 3.5 1 .1-.8.4-1.3.8-1.6-2.7-.3-5.5-1.3-5.5-6 0-1.3.5-2.4 1.2-3.2-.1-.3-.5-1.5.1-3.2 0 0 1-.3 3.3 1.2a11.5 11.5 0 0 1 6 0c2.3-1.5 3.3-1.2 3.3-1.2.6 1.7.2 2.9.1 3.2.8.8 1.2 1.9 1.2 3.2 0 4.7-2.8 5.7-5.5 6 .4.4.8 1.1.8 2.2v3.3c0 .3.2.7.8.6A12 12 0 0 0 12 0z" />
+                </svg>
+                GitHubでアカウント作成
+              </button>
+            </div>
+
+            {/* Divider */}
+            <div className="relative">
+              <div className="absolute inset-0 flex items-center">
+                <div className="w-full border-t border-gray-300" />
+              </div>
+              <div className="relative flex justify-center text-sm">
+                <span className="px-2 bg-white text-gray-500">または</span>
+              </div>
+            </div>
+
+            {/* Email Form */}
+            <form className="space-y-6">
+              <div>
+                <label htmlFor="email" className="block text-sm font-medium text-gray-700">
+                  メールアドレス
+                </label>
+                <div className="mt-1">
+                  <input
+                    id="email"
+                    name="email"
+                    type="email"
+                    autoComplete="email"
+                    required
+                    className="appearance-none block w-full px-3 py-2 border border-gray-300 rounded-lg placeholder-gray-400 focus:outline-none focus:ring-blue-500 focus:border-blue-500 sm:text-sm"
+                    placeholder="your@example.com"
+                  />
+                </div>
+              </div>
+
+              <div>
+                <label htmlFor="password" className="block text-sm font-medium text-gray-700">
+                  パスワード
+                </label>
+                <div className="mt-1">
+                  <input
+                    id="password"
+                    name="password"
+                    type="password"
+                    autoComplete="new-password"
+                    required
+                    className="appearance-none block w-full px-3 py-2 border border-gray-300 rounded-lg placeholder-gray-400 focus:outline-none focus:ring-blue-500 focus:border-blue-500 sm:text-sm"
+                    placeholder="パスワードを入力"
+                  />
+                </div>
+              </div>
+
+              <div>
+                <label htmlFor="password-confirm" className="block text-sm font-medium text-gray-700">
+                  パスワード確認
+                </label>
+                <div className="mt-1">
+                  <input
+                    id="password-confirm"
+                    name="password-confirm"
+                    type="password"
+                    autoComplete="new-password"
+                    required
+                    className="appearance-none block w-full px-3 py-2 border border-gray-300 rounded-lg placeholder-gray-400 focus:outline-none focus:ring-blue-500 focus:border-blue-500 sm:text-sm"
+                    placeholder="パスワードを再入力"
+                  />
+                </div>
+              </div>
+
+              <div>
+                <button
+                  type="submit"
+                  className="group relative w-full flex justify-center py-3 px-4 border border-transparent text-sm font-medium rounded-lg text-white bg-blue-600 hover:bg-blue-700 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-blue-500 transition-colors"
+                >
+                  アカウントを作成
+                </button>
+              </div>
+            </form>
+
+            {/* Login Link */}
+            <div className="text-center">
+              <p className="text-sm text-gray-600">
+                既にアカウントをお持ちですか？{' '}
+                <a href="/login" className="font-medium text-blue-600 hover:text-blue-500">
+                  ログインはこちら
+                </a>
+              </p>
+            </div>
+          </div>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/app/routes/register.tsx
+++ b/app/routes/register.tsx
@@ -3,7 +3,8 @@ export function meta() {
     { title: 'アカウント登録 - ProfNode' },
     {
       name: 'description',
-      content: 'ProfNodeでアカウントを作成して、あなただけのデジタル名刺を始めましょう。',
+      content:
+        'ProfNodeでアカウントを作成して、あなただけのデジタル名刺を始めましょう。',
     },
   ];
 }
@@ -13,12 +14,8 @@ export default function Register() {
     <div className="min-h-screen animated-gradient flex flex-col justify-center py-12 sm:px-6 lg:px-8">
       <div className="sm:mx-auto sm:w-full sm:max-w-md">
         <div className="text-center">
-          <h1 className="text-3xl font-black text-gray-900 mb-2">
-            ProfNode
-          </h1>
-          <h2 className="text-xl font-bold text-gray-700">
-            アカウント作成
-          </h2>
+          <h1 className="text-3xl font-black text-gray-900 mb-2">ProfNode</h1>
+          <h2 className="text-xl font-bold text-gray-700">アカウント作成</h2>
           <p className="mt-2 text-sm text-gray-600">
             あなただけのデジタル名刺を始めましょう
           </p>
@@ -62,7 +59,11 @@ export default function Register() {
                 type="button"
                 className="w-full flex justify-center items-center px-4 py-3 border border-gray-300 rounded-lg shadow-sm bg-white text-sm font-medium text-gray-700 hover:bg-gray-50 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-gray-500 transition-colors"
               >
-                <svg className="w-5 h-5 mr-3" fill="currentColor" viewBox="0 0 24 24">
+                <svg
+                  className="w-5 h-5 mr-3"
+                  fill="currentColor"
+                  viewBox="0 0 24 24"
+                >
                   <path d="M12 0a12 12 0 0 0-3.8 23.4c.6.1.8-.3.8-.6v-2.2c-3.3.7-4-1.6-4-1.6-.5-1.4-1.3-1.8-1.3-1.8-1.1-.7.1-.7.1-.7 1.2.1 1.8 1.2 1.8 1.2 1.1 1.8 2.8 1.3 3.5 1 .1-.8.4-1.3.8-1.6-2.7-.3-5.5-1.3-5.5-6 0-1.3.5-2.4 1.2-3.2-.1-.3-.5-1.5.1-3.2 0 0 1-.3 3.3 1.2a11.5 11.5 0 0 1 6 0c2.3-1.5 3.3-1.2 3.3-1.2.6 1.7.2 2.9.1 3.2.8.8 1.2 1.9 1.2 3.2 0 4.7-2.8 5.7-5.5 6 .4.4.8 1.1.8 2.2v3.3c0 .3.2.7.8.6A12 12 0 0 0 12 0z" />
                 </svg>
                 GitHubでアカウント作成
@@ -82,7 +83,10 @@ export default function Register() {
             {/* Email Form */}
             <form className="space-y-6">
               <div>
-                <label htmlFor="email" className="block text-sm font-medium text-gray-700">
+                <label
+                  htmlFor="email"
+                  className="block text-sm font-medium text-gray-700"
+                >
                   メールアドレス
                 </label>
                 <div className="mt-1">
@@ -99,7 +103,10 @@ export default function Register() {
               </div>
 
               <div>
-                <label htmlFor="password" className="block text-sm font-medium text-gray-700">
+                <label
+                  htmlFor="password"
+                  className="block text-sm font-medium text-gray-700"
+                >
                   パスワード
                 </label>
                 <div className="mt-1">
@@ -116,7 +123,10 @@ export default function Register() {
               </div>
 
               <div>
-                <label htmlFor="password-confirm" className="block text-sm font-medium text-gray-700">
+                <label
+                  htmlFor="password-confirm"
+                  className="block text-sm font-medium text-gray-700"
+                >
                   パスワード確認
                 </label>
                 <div className="mt-1">
@@ -146,7 +156,10 @@ export default function Register() {
             <div className="text-center">
               <p className="text-sm text-gray-600">
                 既にアカウントをお持ちですか？{' '}
-                <a href="/login" className="font-medium text-blue-600 hover:text-blue-500">
+                <a
+                  href="/login"
+                  className="font-medium text-blue-600 hover:text-blue-500"
+                >
                   ログインはこちら
                 </a>
               </p>

--- a/app/routes/register.tsx
+++ b/app/routes/register.tsx
@@ -26,7 +26,7 @@ export default function Register() {
     >
       <div className="space-y-6">
         {/* OAuth Buttons */}
-        <div className="grid grid-cols-1 md:grid-cols-2 gap-3">
+        <div className="space-y-3">
           <OAuthButton provider="google">
             <GoogleIcon />
             Googleで登録
@@ -41,7 +41,7 @@ export default function Register() {
         <Divider>または</Divider>
 
         {/* Email Form */}
-        <form className="space-y-6">
+        <form className="space-y-4 sm:space-y-6">
           <FormField
             id="email"
             label="メールアドレス"
@@ -72,7 +72,7 @@ export default function Register() {
           <div>
             <button
               type="submit"
-              className="group relative w-full flex justify-center py-3 px-4 border border-transparent text-sm font-medium rounded-lg text-white bg-blue-600 hover:bg-blue-700 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-blue-500 transition-colors"
+              className="group relative w-full flex justify-center py-2.5 sm:py-3 px-4 border border-transparent text-sm sm:text-base font-medium rounded-lg text-white bg-blue-600 hover:bg-blue-700 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-blue-500 transition-colors"
             >
               登録する
             </button>
@@ -81,7 +81,7 @@ export default function Register() {
 
         {/* Login Link */}
         <div className="text-center">
-          <p className="text-sm text-gray-600">
+          <p className="text-xs sm:text-sm text-gray-600">
             すでにアカウントをお持ちですか？{' '}
             <a
               href="/login"

--- a/app/routes/register.tsx
+++ b/app/routes/register.tsx
@@ -13,7 +13,7 @@ export function meta({}: Route.MetaArgs) {
     {
       name: 'description',
       content:
-        'ProfNodeでアカウントを作成して、あなただけのデジタル名刺を始めましょう。',
+        'ProfNodeに新規登録して、あなただけのデジタル名刺を始めましょう。',
     },
   ];
 }
@@ -23,7 +23,7 @@ export default function Register() {
     <AuthLayout
       title="アカウント作成"
       subtitle=""
-      description="ProfNodeで新しいアカウントを作成"
+      description="ProfNodeに新規登録"
     >
       <div className="space-y-6">
         {/* OAuth Buttons */}

--- a/app/routes/register.tsx
+++ b/app/routes/register.tsx
@@ -1,4 +1,13 @@
-export function meta() {
+import type { Route } from './+types/register';
+import { AuthLayout } from '../components/auth/AuthLayout';
+import {
+  OAuthButton,
+  GoogleIcon,
+  GitHubIcon,
+} from '../components/auth/OAuthButton';
+import { FormField, Divider } from '../components/auth/AuthForm';
+
+export function meta({}: Route.MetaArgs) {
   return [
     { title: 'アカウント登録 - ProfNode' },
     {
@@ -11,162 +20,81 @@ export function meta() {
 
 export default function Register() {
   return (
-    <div className="min-h-screen animated-gradient flex flex-col justify-center py-12 sm:px-6 lg:px-8">
-      <div className="sm:mx-auto sm:w-full sm:max-w-md">
+    <AuthLayout
+      title="アカウント作成"
+      subtitle=""
+      description="ProfNodeで新しいアカウントを作成"
+    >
+      <div className="space-y-6">
+        {/* OAuth Buttons */}
+        <div>
+          <OAuthButton provider="google">
+            <GoogleIcon />
+            Googleでアカウント作成
+          </OAuthButton>
+        </div>
+
+        <div>
+          <OAuthButton provider="github">
+            <GitHubIcon />
+            GitHubでアカウント作成
+          </OAuthButton>
+        </div>
+
+        <Divider>または</Divider>
+
+        {/* Email Form */}
+        <form className="space-y-6">
+          <FormField
+            id="email"
+            label="メールアドレス"
+            type="email"
+            autoComplete="email"
+            placeholder="your@example.com"
+            required
+          />
+
+          <FormField
+            id="password"
+            label="パスワード"
+            type="password"
+            autoComplete="new-password"
+            placeholder="パスワードを入力"
+            required
+          />
+
+          <FormField
+            id="password-confirm"
+            label="パスワード確認"
+            type="password"
+            autoComplete="new-password"
+            placeholder="パスワードを再入力"
+            required
+          />
+
+          <div>
+            <button
+              type="submit"
+              className="group relative w-full flex justify-center py-3 px-4 border border-transparent text-sm font-medium rounded-lg text-white bg-blue-600 hover:bg-blue-700 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-blue-500 transition-colors"
+            >
+              アカウントを作成
+            </button>
+          </div>
+        </form>
+
+        {/* Login Link */}
         <div className="text-center">
-          <h1 className="text-3xl font-black text-gray-900 mb-2">ProfNode</h1>
-          <h2 className="text-xl font-bold text-gray-700">アカウント作成</h2>
-          <p className="mt-2 text-sm text-gray-600">
-            あなただけのデジタル名刺を始めましょう
+          <p className="text-sm text-gray-600">
+            既にアカウントをお持ちですか？{' '}
+            <a
+              href="/login"
+              className="font-medium text-blue-600 hover:text-blue-500"
+            >
+              ログインはこちら
+            </a>
           </p>
         </div>
       </div>
-
-      <div className="mt-8 sm:mx-auto sm:w-full sm:max-w-md">
-        <div className="bg-white/80 backdrop-filter backdrop-blur-md py-8 px-4 shadow-2xl sm:rounded-2xl sm:px-10 border border-gray-200/80">
-          <div className="space-y-6">
-            {/* Google OAuth Button */}
-            <div>
-              <button
-                type="button"
-                className="w-full flex justify-center items-center px-4 py-3 border border-gray-300 rounded-lg shadow-sm bg-white text-sm font-medium text-gray-700 hover:bg-gray-50 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-blue-500 transition-colors"
-              >
-                <svg className="w-5 h-5 mr-3" viewBox="0 0 24 24">
-                  <path
-                    fill="#4285F4"
-                    d="M22.56 12.25c0-.78-.07-1.53-.2-2.25H12v4.26h5.92c-.26 1.37-1.04 2.53-2.21 3.31v2.77h3.57c2.08-1.92 3.28-4.74 3.28-8.09z"
-                  />
-                  <path
-                    fill="#34A853"
-                    d="M12 23c2.97 0 5.46-.98 7.28-2.66l-3.57-2.77c-.98.66-2.23 1.06-3.71 1.06-2.86 0-5.29-1.93-6.16-4.53H2.18v2.84C3.99 20.53 7.7 23 12 23z"
-                  />
-                  <path
-                    fill="#FBBC05"
-                    d="M5.84 14.09c-.22-.66-.35-1.36-.35-2.09s.13-1.43.35-2.09V7.07H2.18C1.43 8.55 1 10.22 1 12s.43 3.45 1.18 4.93l2.85-2.22.81-.62z"
-                  />
-                  <path
-                    fill="#EA4335"
-                    d="M12 5.38c1.62 0 3.06.56 4.21 1.64l3.15-3.15C17.45 2.09 14.97 1 12 1 7.7 1 3.99 3.47 2.18 7.07l3.66 2.84c.87-2.6 3.3-4.53 6.16-4.53z"
-                  />
-                </svg>
-                Googleでアカウント作成
-              </button>
-            </div>
-
-            {/* GitHub OAuth Button */}
-            <div>
-              <button
-                type="button"
-                className="w-full flex justify-center items-center px-4 py-3 border border-gray-300 rounded-lg shadow-sm bg-white text-sm font-medium text-gray-700 hover:bg-gray-50 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-gray-500 transition-colors"
-              >
-                <svg
-                  className="w-5 h-5 mr-3"
-                  fill="currentColor"
-                  viewBox="0 0 24 24"
-                >
-                  <path d="M12 0a12 12 0 0 0-3.8 23.4c.6.1.8-.3.8-.6v-2.2c-3.3.7-4-1.6-4-1.6-.5-1.4-1.3-1.8-1.3-1.8-1.1-.7.1-.7.1-.7 1.2.1 1.8 1.2 1.8 1.2 1.1 1.8 2.8 1.3 3.5 1 .1-.8.4-1.3.8-1.6-2.7-.3-5.5-1.3-5.5-6 0-1.3.5-2.4 1.2-3.2-.1-.3-.5-1.5.1-3.2 0 0 1-.3 3.3 1.2a11.5 11.5 0 0 1 6 0c2.3-1.5 3.3-1.2 3.3-1.2.6 1.7.2 2.9.1 3.2.8.8 1.2 1.9 1.2 3.2 0 4.7-2.8 5.7-5.5 6 .4.4.8 1.1.8 2.2v3.3c0 .3.2.7.8.6A12 12 0 0 0 12 0z" />
-                </svg>
-                GitHubでアカウント作成
-              </button>
-            </div>
-
-            {/* Divider */}
-            <div className="relative">
-              <div className="absolute inset-0 flex items-center">
-                <div className="w-full border-t border-gray-300" />
-              </div>
-              <div className="relative flex justify-center text-sm">
-                <span className="px-2 bg-white text-gray-500">または</span>
-              </div>
-            </div>
-
-            {/* Email Form */}
-            <form className="space-y-6">
-              <div>
-                <label
-                  htmlFor="email"
-                  className="block text-sm font-medium text-gray-700"
-                >
-                  メールアドレス
-                </label>
-                <div className="mt-1">
-                  <input
-                    id="email"
-                    name="email"
-                    type="email"
-                    autoComplete="email"
-                    required
-                    className="appearance-none block w-full px-3 py-2 border border-gray-300 rounded-lg placeholder-gray-400 focus:outline-none focus:ring-blue-500 focus:border-blue-500 sm:text-sm"
-                    placeholder="your@example.com"
-                  />
-                </div>
-              </div>
-
-              <div>
-                <label
-                  htmlFor="password"
-                  className="block text-sm font-medium text-gray-700"
-                >
-                  パスワード
-                </label>
-                <div className="mt-1">
-                  <input
-                    id="password"
-                    name="password"
-                    type="password"
-                    autoComplete="new-password"
-                    required
-                    className="appearance-none block w-full px-3 py-2 border border-gray-300 rounded-lg placeholder-gray-400 focus:outline-none focus:ring-blue-500 focus:border-blue-500 sm:text-sm"
-                    placeholder="パスワードを入力"
-                  />
-                </div>
-              </div>
-
-              <div>
-                <label
-                  htmlFor="password-confirm"
-                  className="block text-sm font-medium text-gray-700"
-                >
-                  パスワード確認
-                </label>
-                <div className="mt-1">
-                  <input
-                    id="password-confirm"
-                    name="password-confirm"
-                    type="password"
-                    autoComplete="new-password"
-                    required
-                    className="appearance-none block w-full px-3 py-2 border border-gray-300 rounded-lg placeholder-gray-400 focus:outline-none focus:ring-blue-500 focus:border-blue-500 sm:text-sm"
-                    placeholder="パスワードを再入力"
-                  />
-                </div>
-              </div>
-
-              <div>
-                <button
-                  type="submit"
-                  className="group relative w-full flex justify-center py-3 px-4 border border-transparent text-sm font-medium rounded-lg text-white bg-blue-600 hover:bg-blue-700 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-blue-500 transition-colors"
-                >
-                  アカウントを作成
-                </button>
-              </div>
-            </form>
-
-            {/* Login Link */}
-            <div className="text-center">
-              <p className="text-sm text-gray-600">
-                既にアカウントをお持ちですか？{' '}
-                <a
-                  href="/login"
-                  className="font-medium text-blue-600 hover:text-blue-500"
-                >
-                  ログインはこちら
-                </a>
-              </p>
-            </div>
-          </div>
-        </div>
-      </div>
-    </div>
+    </AuthLayout>
   );
 }

--- a/app/routes/register.tsx
+++ b/app/routes/register.tsx
@@ -9,11 +9,10 @@ import { FormField, Divider } from '../components/auth/AuthForm';
 
 export function meta({}: Route.MetaArgs) {
   return [
-    { title: 'アカウント登録 - ProfNode' },
+    { title: 'ユーザー登録 - ProfNode' },
     {
       name: 'description',
-      content:
-        'ProfNodeに新規登録して、あなただけのデジタル名刺を始めましょう。',
+      content: 'ProfNodeに登録して、あなただけのデジタル名刺を作成しましょう。',
     },
   ];
 }
@@ -21,23 +20,21 @@ export function meta({}: Route.MetaArgs) {
 export default function Register() {
   return (
     <AuthLayout
-      title="アカウント作成"
+      title="ProfNodeに登録"
       subtitle=""
-      description="ProfNodeに新規登録"
+      description="新規登録(無料)して利用を開始しましょう。"
     >
       <div className="space-y-6">
         {/* OAuth Buttons */}
-        <div>
+        <div className="grid grid-cols-1 md:grid-cols-2 gap-3">
           <OAuthButton provider="google">
             <GoogleIcon />
-            Googleでアカウント作成
+            Googleで登録
           </OAuthButton>
-        </div>
 
-        <div>
           <OAuthButton provider="github">
             <GitHubIcon />
-            GitHubでアカウント作成
+            GitHubで登録
           </OAuthButton>
         </div>
 
@@ -77,7 +74,7 @@ export default function Register() {
               type="submit"
               className="group relative w-full flex justify-center py-3 px-4 border border-transparent text-sm font-medium rounded-lg text-white bg-blue-600 hover:bg-blue-700 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-blue-500 transition-colors"
             >
-              アカウントを作成
+              登録する
             </button>
           </div>
         </form>
@@ -85,12 +82,12 @@ export default function Register() {
         {/* Login Link */}
         <div className="text-center">
           <p className="text-sm text-gray-600">
-            既にアカウントをお持ちですか？{' '}
+            すでにアカウントをお持ちですか？{' '}
             <a
               href="/login"
               className="font-medium text-blue-600 hover:text-blue-500"
             >
-              ログインはこちら
+              ログイン
             </a>
           </p>
         </div>

--- a/docs/directory-sample.txt
+++ b/docs/directory-sample.txt
@@ -1,4 +1,4 @@
-📦 web-business-card/
+じょう📦 web-business-card/
 ├── 📂 app/                              # React Router v7 アプリケーション
 │   ├── 📜 routes.ts                     # ルート設定（Configuration-based）
 │   ├── 📜 root.tsx                      # ルートコンポーネント


### PR DESCRIPTION
## Summary
- `/register`ルートのページコンポーネント作成
- GoogleとGitHubのOAuth認証レイアウト実装
- ランディングページから登録ページへのナビゲーション追加

## 実装内容
- 新規ルート `/register` を追加
- OAuth（Google・GitHub）とメール認証の両方に対応
- レスポンシブデザイン対応
- 既存のランディングページデザインと統一
- 型安全性を確保

## Test plan
- [ ] `/register`ページが正常に表示される
- [ ] ランディングページからのナビゲーションが正常に動作する
- [ ] レスポンシブデザインが正常に機能する 
- [ ] OAuth認証UIが視覚的に正常に表示される
- [ ] フォームバリデーションUI（現在は表示のみ）が正常に動作する

## 関連issue
closes #31

🤖 Generated with [Claude Code](https://claude.ai/code)