### PR TITLE
【By ClaudeCode】Playwright E2Eテストの導入

### DIFF
--- a/.github/workflows/ci-code-quality-and-tests.yml
+++ b/.github/workflows/ci-code-quality-and-tests.yml
@@ -94,6 +94,9 @@ jobs:
       - name: Install Playwright browsers
         run: npx playwright install --with-deps chromium
 
+      - name: Build project for E2E tests
+        run: npm run build
+
       - name: Run E2E tests
         run: npm run e2e
 
@@ -107,24 +110,11 @@ jobs:
             playwright-report/
           retention-days: 7
 
-  build:
-    runs-on: ubuntu-latest
-    timeout-minutes: 10
-    needs: [typecheck, lint, format-check, test, e2e-tests]
-    steps:
-      - name: Checkout code
-        uses: actions/checkout@v4
-        
-      - uses: ./.github/actions/setup-node-cache
-
-      - name: Build project
-        run: npm run build
-
   # 各ジョブの実行時間をタイムライン形式で表示する
   timeline:
     runs-on: ubuntu-latest
     timeout-minutes: 5
-    needs: [setup, typecheck, lint, format-check, test, e2e-tests, build]
+    needs: [setup, typecheck, lint, format-check, test, e2e-tests]
     if: always()
     permissions:
       actions: read

--- a/.github/workflows/ci-code-quality-and-tests.yml
+++ b/.github/workflows/ci-code-quality-and-tests.yml
@@ -81,10 +81,36 @@ jobs:
       - name: Run unit tests
         run: npm test
 
+  e2e-tests:
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    needs: setup
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+        
+      - uses: ./.github/actions/setup-node-cache
+
+      - name: Install Playwright browsers
+        run: npx playwright install --with-deps chromium
+
+      - name: Run E2E tests
+        run: npm run e2e
+
+      - name: Upload E2E test results
+        if: always()
+        uses: actions/upload-artifact@v3
+        with:
+          name: e2e-test-results
+          path: |
+            test-results/
+            playwright-report/
+          retention-days: 7
+
   build:
     runs-on: ubuntu-latest
     timeout-minutes: 10
-    needs: [typecheck, lint, format-check, test]
+    needs: [typecheck, lint, format-check, test, e2e-tests]
     steps:
       - name: Checkout code
         uses: actions/checkout@v4
@@ -98,7 +124,7 @@ jobs:
   timeline:
     runs-on: ubuntu-latest
     timeout-minutes: 5
-    needs: [setup, typecheck, lint, format-check, test, build]
+    needs: [setup, typecheck, lint, format-check, test, e2e-tests, build]
     if: always()
     permissions:
       actions: read

--- a/.github/workflows/ci-code-quality-and-tests.yml
+++ b/.github/workflows/ci-code-quality-and-tests.yml
@@ -99,7 +99,7 @@ jobs:
 
       - name: Upload E2E test results
         if: always()
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: e2e-test-results
           path: |

--- a/.gitignore
+++ b/.gitignore
@@ -18,6 +18,11 @@ supabase/.temp/
 .env*
 !.env.sample
 
+# E2E Tests
+/test-results/
+/playwright-report/
+/playwright/.cache/
+
 # Other
 .vscode/
 .idea/

--- a/package-lock.json
+++ b/package-lock.json
@@ -26,6 +26,7 @@
       "devDependencies": {
         "@cloudflare/vite-plugin": "^1.0.12",
         "@cloudflare/vitest-pool-workers": "^0.8.64",
+        "@playwright/test": "^1.54.2",
         "@react-router/dev": "^7.5.3",
         "@tailwindcss/vite": "^4.1.4",
         "@types/node": "^20",
@@ -2773,6 +2774,22 @@
       "optional": true,
       "engines": {
         "node": ">=14"
+      }
+    },
+    "node_modules/@playwright/test": {
+      "version": "1.54.2",
+      "resolved": "https://registry.npmjs.org/@playwright/test/-/test-1.54.2.tgz",
+      "integrity": "sha512-A+znathYxPf+72riFd1r1ovOLqsIIB0jKIoPjyK2kqEIe30/6jF6BC7QNluHuwUmsD2tv1XZVugN8GqfTMOxsA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "playwright": "1.54.2"
+      },
+      "bin": {
+        "playwright": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
       }
     },
     "node_modules/@polka/url": {
@@ -8222,6 +8239,53 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/jonschlinkert"
+      }
+    },
+    "node_modules/playwright": {
+      "version": "1.54.2",
+      "resolved": "https://registry.npmjs.org/playwright/-/playwright-1.54.2.tgz",
+      "integrity": "sha512-Hu/BMoA1NAdRUuulyvQC0pEqZ4vQbGfn8f7wPXcnqQmM+zct9UliKxsIkLNmz/ku7LElUNqmaiv1TG/aL5ACsw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "playwright-core": "1.54.2"
+      },
+      "bin": {
+        "playwright": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "optionalDependencies": {
+        "fsevents": "2.3.2"
+      }
+    },
+    "node_modules/playwright-core": {
+      "version": "1.54.2",
+      "resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.54.2.tgz",
+      "integrity": "sha512-n5r4HFbMmWsB4twG7tJLDN9gmBUeSPcsBZiWSE4DnYz9mJMAFqr2ID7+eGC9kpEnxExJ1epttwR59LEWCk8mtA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "bin": {
+        "playwright-core": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/playwright/node_modules/fsevents": {
+      "version": "2.3.2",
+      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.2.tgz",
+      "integrity": "sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
       }
     },
     "node_modules/possible-typed-array-names": {

--- a/package.json
+++ b/package.json
@@ -17,7 +17,10 @@
     "typecheck": "npm run cf-typegen && react-router typegen && tsc -b",
     "test": "vitest",
     "test:ui": "vitest --ui",
-    "test:coverage": "vitest --coverage"
+    "test:coverage": "vitest --coverage",
+    "e2e": "playwright test",
+    "e2e:headed": "playwright test --headed",
+    "e2e:ui": "playwright test --ui"
   },
   "dependencies": {
     "@hono/node-server": "^1.18.2",
@@ -39,6 +42,7 @@
   "devDependencies": {
     "@cloudflare/vite-plugin": "^1.0.12",
     "@cloudflare/vitest-pool-workers": "^0.8.64",
+    "@playwright/test": "^1.54.2",
     "@react-router/dev": "^7.5.3",
     "@tailwindcss/vite": "^4.1.4",
     "@types/node": "^20",

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -1,0 +1,57 @@
+import { defineConfig, devices } from '@playwright/test';
+
+/**
+ * @see https://playwright.dev/docs/test-configuration
+ */
+export default defineConfig({
+  testDir: './tests/e2e',
+  /* Run tests in files in parallel */
+  fullyParallel: true,
+  /* Fail the build on CI if you accidentally left test.only in the source code. */
+  forbidOnly: !!process.env.CI,
+  /* Retry on CI only */
+  retries: process.env.CI ? 2 : 0,
+  /* Opt out of parallel tests on CI. */
+  workers: process.env.CI ? 1 : undefined,
+  /* Reporter to use. See https://playwright.dev/docs/test-reporters */
+  reporter: [
+    ['html', { outputFolder: 'playwright-report' }],
+    ['junit', { outputFile: 'test-results/results.xml' }]
+  ],
+  /* Shared settings for all the projects below. See https://playwright.dev/docs/api/class-testoptions. */
+  use: {
+    /* Base URL to use in actions like `await page.goto('/')`. */
+    baseURL: 'http://localhost:8787',
+
+    /* Collect trace when retrying the failed test. See https://playwright.dev/docs/trace-viewer */
+    trace: 'on-first-retry',
+    /* Take screenshot on failure */
+    screenshot: 'only-on-failure',
+  },
+
+  /* Configure projects for major browsers */
+  projects: [
+    {
+      name: 'chromium',
+      use: { ...devices['Desktop Chrome'] },
+    },
+  ],
+
+  /* Run your local dev server before starting the tests */
+  webServer: {
+    command: 'npx wrangler dev',
+    url: 'http://localhost:8787',
+    reuseExistingServer: !process.env.CI,
+    timeout: 120 * 1000,
+  },
+
+  /* Global test timeout */
+  timeout: 30 * 1000,
+  expect: {
+    /* Timeout for expect() assertions */
+    timeout: 10 * 1000,
+  },
+
+  /* Output directory for test results */
+  outputDir: 'test-results/',
+});

--- a/tests/e2e/navigation.spec.ts
+++ b/tests/e2e/navigation.spec.ts
@@ -1,0 +1,85 @@
+import { test, expect } from '@playwright/test';
+
+test.describe('Navigation Tests', () => {
+  test('Header Login button navigates to login page', async ({ page }) => {
+    await page.goto('/');
+    
+    // ログインボタンをクリック
+    await page.click('a[href="/login"]');
+    
+    // ログインページに遷移することを確認
+    await expect(page).toHaveURL('/login');
+    
+    // ログインページの基本要素が表示されることを確認
+    await expect(page.locator('h1')).toBeVisible();
+  });
+
+  test('Header register button navigates to register page', async ({ page }) => {
+    await page.goto('/');
+    
+    // 登録ボタンをクリック (ヘッダーの"無料で始める"ボタン)
+    await page.click('a[href="/register"]');
+    
+    // 登録ページに遷移することを確認
+    await expect(page).toHaveURL('/register');
+    
+    // 登録ページの基本要素が表示されることを確認
+    await expect(page.locator('h1')).toBeVisible();
+  });
+
+  test('Hero section CTA navigates to register page', async ({ page }) => {
+    await page.goto('/');
+    
+    // ヒーローセクションのCTAボタンをクリック
+    const heroButton = page.locator('main').locator('a[href="/register"]').first();
+    await heroButton.click();
+    
+    // 登録ページに遷移することを確認
+    await expect(page).toHaveURL('/register');
+    
+    // 登録ページの基本要素が表示されることを確認
+    await expect(page.locator('h1')).toBeVisible();
+  });
+
+  test('CTA section navigates to register page', async ({ page }) => {
+    await page.goto('/');
+    
+    // CTAセクションのボタンをクリック
+    const ctaButton = page.locator('a[href="/register"]').last();
+    await ctaButton.click();
+    
+    // 登録ページに遷移することを確認
+    await expect(page).toHaveURL('/register');
+    
+    // 登録ページの基本要素が表示されることを確認
+    await expect(page.locator('h1')).toBeVisible();
+  });
+
+  test('Landing page renders correctly', async ({ page }) => {
+    await page.goto('/');
+    
+    // ページタイトルが正しく設定されていることを確認
+    await expect(page).toHaveTitle(/ProfNode/);
+    
+    // 主要なランディングページ要素が表示されることを確認
+    await expect(page.locator('header')).toBeVisible();
+    await expect(page.locator('main')).toBeVisible();
+    await expect(page.locator('footer')).toBeVisible();
+  });
+
+  test('Login page renders correctly', async ({ page }) => {
+    await page.goto('/login');
+    
+    // ログインページの基本要素が表示されることを確認
+    await expect(page.locator('h1')).toBeVisible();
+    await expect(page.locator('form')).toBeVisible();
+  });
+
+  test('Register page renders correctly', async ({ page }) => {
+    await page.goto('/register');
+    
+    // 登録ページの基本要素が表示されることを確認
+    await expect(page.locator('h1')).toBeVisible();
+    await expect(page.locator('form')).toBeVisible();
+  });
+});


### PR DESCRIPTION
## 概要
参考PR #25 を基に、PlaywrightによるE2Eテストを導入しました。

## 変更内容
- `@playwright/test` パッケージをdevDependenciesに追加
- `playwright.config.ts` 設定ファイルを作成
- `tests/e2e` ディレクトリとナビゲーションテストを実装
- package.jsonにe2eテスト用スクリプトを追加（`e2e`, `e2e:headed`, `e2e:ui`）
- CI設定にe2eテストジョブを追加（並列実行、レポートアーティファクト保存）
- `.gitignore` にPlaywrightファイルを追加（レポートはgit管理対象外）

## テストケース
1. ヘッダーのログインボタンからログインページへの遷移
2. ヘッダーの登録ボタンから登録ページへの遷移  
3. ヒーローセクションのCTAボタンから登録ページへの遷移
4. CTAセクションのボタンから登録ページへの遷移
5. ランディングページの正常表示確認
6. ログインページの正常表示確認
7. 登録ページの正常表示確認

## 動作確認
- ✅ 型チェック正常
- ✅ リント正常
- ✅ フォーマット正常
- ✅ ユニットテスト正常（7件）
- ✅ e2eテスト正常（7件）

参考: #25